### PR TITLE
FIX: Impedance setting for firmware v2 and over

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Python researcher or developer? Check out how easy it is to [get access to the e
 ### Table of Contents:
 ---
 
-1. [TL;DR](#tldr)
-2. [Installation](#install)
+1. [Installation](#install)
+2. [TL;DR](#tldr)
 3. [Cyton (32bit Board)](#cyton)
   1. [About](#about)
   2. [General Overview](#general-overview)
@@ -148,9 +148,11 @@ ourBoard.connect(k.OBCISimulatorPortName) // This will set `simulate` to true
     });
 ```
 
+You can also start the simulator by sending [`.connect(portName)`](#method-connect) with `portName` equal to [`'OpenBCISimulator'`](#constants-obcisimulatorportname).
+
 or if you are using ES6:
 ```js
-import { Cyton } from 'openbci';
+import Cyton from 'openbci-cyton';
 import { Constants } from 'openbci-utilities';
 const ourBoard = new Cyton();
 ourBoard.connect(Constants.OBCISimulatorPortName);
@@ -187,16 +189,16 @@ Sample properties:
 ------------------
 * `startByte` (`Number` should be `0xA0`)
 * `sampleNumber` (a `Number` between 0-255)
-* `channelData` (channel data indexed at 0 filled with floating point `Numbers` in Volts)
-* `accelData` (`Array` with X, Y, Z accelerometer values when new data available)
+* `channelData` (channel data indexed at 0 filled with floating point `Numbers` in Volts) if `sendCounts` is false
+* `channelDataCounts` (channel data indexed at 0 filled with floating point `Numbers` in Volts) if `sendCounts` is true
+* `accelData` (`Array` with X, Y, Z accelerometer values when new data available) if `sendCounts` is false
+* `accelDataCounts` (`Array` with X, Y, Z accelerometer values when new data available) Only present if `sendCounts` is true
 * `auxData` (`Buffer` filled with either 2 bytes (if time synced) or 6 bytes (not time synced))
 * `stopByte` (`Number` should be `0xCx` where x is 0-15 in hex)
 * `boardTime` (`Number` the raw board time)
 * `timeStamp` (`Number` the `boardTime` plus the NTP calculated offset)
 
 The power of this module is in using the sample emitter, to be provided with samples to do with as you wish.
-
-You can also start the simulator by sending [`.connect(portName)`](#method-connect) with `portName` equal to [`'OpenBCISimulator'`](#constants-obcisimulatorportname).
 
 To get a ['sample'](#event-sample) event, you need to:
 -------------------------------------

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # 1.0.4
 
+### New Features
+
+* Add function `impedanceSet` which is similar to `channelSet` in that it just sends commands and then forgets about them.
+
 ### Bug Fixes
 
 * Fixed lead off command sending for v2 firmware and later.

--- a/examples/getStreaming/getStreaming.js
+++ b/examples/getStreaming/getStreaming.js
@@ -12,7 +12,7 @@
 const debug = false; // Pretty print any bytes in and out... it's amazing...
 const verbose = true; // Adds verbosity to functions
 
-const Cyton = require('../../index').Cyton;
+const Cyton = require('../../openBCICyton');
 let ourBoard = new Cyton({
   debug: debug,
   verbose: verbose

--- a/openBCICyton.js
+++ b/openBCICyton.js
@@ -1313,7 +1313,6 @@ Cyton.prototype.testSignal = function (signal) {
  * @author AJ Keller (@aj-ptw)
  */
 Cyton.prototype.impedanceSet = function (channelNumber, pInputApplied, nInputApplied) {
-  let arrayOfCommands = [];
   return new Promise((resolve, reject) => {
     k.getImpedanceSetter(channelNumber, pInputApplied, nInputApplied)
       .then((val) => {

--- a/openBCICyton.js
+++ b/openBCICyton.js
@@ -1305,6 +1305,29 @@ Cyton.prototype.testSignal = function (signal) {
 };
 
 /**
+ * @description To send an impedance setting command to the board
+ * @param channelNumber {Number} (1-16)
+ * @param pInputApplied {Boolean} (true -> ON, false -> OFF (default))
+ * @param nInputApplied {Boolean} (true -> ON, false -> OFF (default))
+ * @returns {Promise} resolves if sent, rejects on bad input or no board
+ * @author AJ Keller (@aj-ptw)
+ */
+Cyton.prototype.impedanceSet = function (channelNumber, pInputApplied, nInputApplied) {
+  let arrayOfCommands = [];
+  return new Promise((resolve, reject) => {
+    k.getImpedanceSetter(channelNumber, pInputApplied, nInputApplied)
+      .then((val) => {
+        if (this.usingAtLeastVersionTwoFirmware()) {
+          const buf = Buffer.from(val.join(''));
+          return this._writeAndDrain(buf);
+        } else {
+          return this.write(val);
+        }
+      }).then(resolve, reject);
+  });
+};
+
+/**
  * @description - Sends command to turn on impedances for all channels and continuously calculate their impedances
  * @returns {Promise} - Fulfills when all the commands are sent to the internal write buffer
  * @author AJ Keller (@pushtheworldllc)

--- a/test/openBCICyton-test.js
+++ b/test/openBCICyton-test.js
@@ -1362,7 +1362,7 @@ describe('openbci-sdk', function () {
       });
       after(() => {
         ourBoard.options.simulatorFirmwareVersion = firmwareVersion;
-      })
+      });
       it('should call the writeAndDrain function with single string for firmware v2+', function (done) {
         spy.reset();
         ourBoard.options.simulatorFirmwareVersion = 'v2';

--- a/test/openBCICyton-test.js
+++ b/test/openBCICyton-test.js
@@ -1345,6 +1345,55 @@ describe('openbci-sdk', function () {
         ourBoard.channelSet(1, true, 24, 'normal', 'taco', true, true).should.be.rejected.and.notify(done);
       });
     });
+    describe('#impedanceSet', function () {
+      this.timeout(6000);
+      let firmwareVersion;
+      before(function (done) {
+        if (!ourBoard.isConnected()) {
+          firmwareVersion = ourBoard.options.simulatorFirmwareVersion;
+          ourBoard.connect(masterPortName)
+            .then((done) => {
+
+            })
+            .catch(err => done(err));
+        } else {
+          done();
+        }
+      });
+      after(() => {
+        ourBoard.options.simulatorFirmwareVersion = firmwareVersion;
+      })
+      it('should call the writeAndDrain function with single string for firmware v2+', function (done) {
+        spy.reset();
+        ourBoard.options.simulatorFirmwareVersion = 'v2';
+        ourBoard.impedanceSet(4, false, true)
+          .then(() => {
+            setTimeout(() => {
+              spy.should.have.been.calledWith(Buffer.from('z401Z'));
+              done();
+            }, 15 * k.OBCIWriteIntervalDelayMSShort);
+          })
+          .catch(err => done(err));
+      });
+      it('should call the writeAndDrain function array of commands 9 times for firmware v1', function (done) {
+        ourBoard.options.simulatorFirmwareVersion = 'v1';
+        setTimeout(() => {
+          spy.reset();
+          ourBoard.impedanceSet(1, true, true)
+            .then(() => {
+              setTimeout(() => {
+                spy.callCount.should.equal(5);
+                done();
+              }, 15 * k.OBCIWriteIntervalDelayMSShort);
+            })
+            .catch(err => done(err));
+        }, 10 * k.OBCIWriteIntervalDelayMSShort); // give some time for writer to finish
+      });
+
+      it('should be rejected', function (done) {
+        ourBoard.impedanceSet(1, true, 'taco').should.be.rejected.and.notify(done);
+      });
+    });
     describe('#syncRegisterSettings', function () {
       this.timeout(6000);
       before(function (done) {


### PR DESCRIPTION
# 1.0.4

### New Features

* Add function `impedanceSet` which is similar to `channelSet` in that it just sends commands and then forgets about them.

### Bug Fixes

* Fixed lead off command sending for v2 firmware and later.