### PR TITLE
FIX: stopByte for daisy sample

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 1.0.6
+
+### Bug Fixes
+
+* Daisy samples now get stop bytes with utilities bump to v0.2.7
+
 # 1.0.4/5
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-cyton",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "The official Node.js SDK for the OpenBCI Cyton with Dongle.",
   "main": "openBCICyton.js",
   "scripts": {
@@ -19,7 +19,7 @@
     "buffer-equal": "^1.0.0",
     "lodash": "^4.17.4",
     "mathjs": "^3.14.2",
-    "openbci-utilities": "^0.2.2",
+    "openbci-utilities": "^0.2.7",
     "safe-buffer": "^5.1.1",
     "serialport": "4.0.7",
     "sntp": "^2.0.2"


### PR DESCRIPTION
# 1.0.6

### Bug Fixes

* Daisy samples now get stop bytes with utilities bump to v0.2.7