### PR TITLE
Fix constants for openbci-utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Go [checkout out the get streaming with daisy example](examples/getStreamingDais
 Another useful way to start the simulator:
 ```js
 const Cyton = require('openbci-cyton');
-const k = require('openbci-utilities').Constants;
+const k = require('openbci-utilities').constants;
 const ourBoard = new Cyton();
 ourBoard.connect(k.OBCISimulatorPortName) // This will set `simulate` to true
     .then((boardSerial) => {
@@ -152,9 +152,9 @@ You can also start the simulator by sending [`.connect(portName)`](#method-conne
 or if you are using ES6:
 ```js
 import Cyton from 'openbci-cyton';
-import { Constants } from 'openbci-utilities';
+import { constants } from 'openbci-utilities';
 const ourBoard = new Cyton();
-ourBoard.connect(Constants.OBCISimulatorPortName);
+ourBoard.connect(constants.OBCISimulatorPortName);
 ```
 
 To debug, it's amazing, do:
@@ -233,7 +233,7 @@ Keep your resync interval above 50ms. While it's important to resync every coupl
 Using local computer time:
 ```js
 const Cyton = require('openbci-cyton');
-const k = require('openbci-utilities').Constants;
+const k = require('openbci-utilities').constants;
 const ourBoard = new Cyton({
   verbose:true
 });
@@ -1179,7 +1179,7 @@ Emitted when there is a new sample available.
 
 To use the constants file simply:
 ```js
-const k = require('openbci-utilities').Constants;
+const k = require('openbci-utilities').constants;
 
 console.log(k.OBCISimulatorPortName); // prints OpenBCISimulator to the console.
 ```


### PR DESCRIPTION
`openbci-utilities` exposes `constants` instead of `Constants`.

https://github.com/OpenBCI/OpenBCI_JavaScript_Utilities/blob/0b7e19904b6746bd0d67278d05122211edef96c8/src/index.js#L6